### PR TITLE
Propagate focus from the host to px-datetime-field

### DIFF
--- a/px-datetime-picker.html
+++ b/px-datetime-picker.html
@@ -231,6 +231,13 @@ Custom property | Description
       this.$.content.addEventListener('temp-moment-obj-changed', this._tempMomentChanged.bind(this, 'content'));
     },
 
+    /*
+     * Propagate focus from the host to px-datetime-field
+     */
+    focus: function() {
+      this.$.field.focus();
+    },
+
     /**
      */
     _onEsc: function(evt) {

--- a/test/px-datetime-picker-custom-tests.js
+++ b/test/px-datetime-picker-custom-tests.js
@@ -73,6 +73,13 @@ describe('px-datetime-picker no buttons', function () {
   });
 
 
+  it('host should propagate focus to the px-datetime-field', function () {
+    var fieldEl = Polymer.dom(pickerEl.root).querySelector('px-datetime-field');
+    pickerEl.focus();
+    assert.equal(fieldEl, Polymer.dom(pickerEl.root).activeElement);
+  });
+
+
   //This should pass but there is a bug that needs to be fixed.
   it('focusing on the field doesn\'t close calendar when opened', function (done) {
     pickerEl.opened = true;


### PR DESCRIPTION
Fixes #30 

Depends on https://github.com/PredixDev/px-datetime-field/pull/8

---

:warning: Tests are failing because of https://github.com/PredixDev/px-datetime-field/pull/8 should be merged and the new version of `px-datetime-field` should be released first.

Once the new version of `px-datetime-field` is released, I will retrigger the CI build for this PR and it will pass.